### PR TITLE
Upgrade Embassy version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly-2021-12-16-x86_64
+        target: thumbv7em-none-eabihf
         override: true
         components: rustfmt, clippy
 
@@ -37,7 +38,7 @@ jobs:
       env:
         RUSTFLAGS: -Dwarnings
       working-directory: ./client
-      run: cargo clippy
+      run: cargo clippy --target thumbv7em-none-eabihf
 
     - name: Format client
       working-directory: ./client
@@ -51,7 +52,7 @@ jobs:
       env:
         RUSTFLAGS: -Dwarnings
       working-directory: ./server
-      run: cargo clippy
+      run: cargo clippy --target thumbv7em-none-eabihf
 
     - name: Format server
       working-directory: ./server

--- a/client/README.md
+++ b/client/README.md
@@ -22,10 +22,11 @@ Testing the app
 ---
 
 ```
+cd app
 cargo test
 ```
 
-Running the app on an nRF52840-dk
+Running the app
 ---
 
 Ensure that probe-run is installed:
@@ -40,15 +41,13 @@ We also use flip-link so that we are more able to detect stack overflows:
 cargo install flip-link
 ```
 
-...then if you want the nRF52840:
+...then if you want the nRF52840, `cd embedded-app` and:
 
 ```
-PROBE_RUN_PROBE='1366:1015' \
 DEFMT_LOG=debug \
+PROBE_RUN_PROBE='1366:1015' \
 PROBE_RUN_CHIP='nrf52840_xxAA' \
-cargo run --no-default-features \
-  --target thumbv7em-none-eabihf \
-  --features "nrf52840-dk"
+cargo run
 ```
 
 (change the `DEFMT_LOG` env as required or even omit it for no logging).
@@ -56,8 +55,8 @@ cargo run --no-default-features \
 Here's an example that runs on the nRF9160 DK in secure mode instead:
 
 ```
-PROBE_RUN_PROBE='1366:1055' \
 DEFMT_LOG=debug \
+PROBE_RUN_PROBE='1366:1055' \
 PROBE_RUN_CHIP='nrf9160_xxAA' \
 cargo run --no-default-features \
   --target thumbv8m.main-none-eabihf \
@@ -71,17 +70,18 @@ cargo run --no-default-features \
 Similarly, for the microbit:v2:
 
 ```
-PROBE_RUN_PROBE='0d28:0204' \
 DEFMT_LOG=debug \
+PROBE_RUN_PROBE='0d28:0204' \
 PROBE_RUN_CHIP='nrf52833_xxAA' \
 cargo run --target thumbv7em-none-eabihf --features "microbit-v2" --no-default-features
 ```
-For an STM32 board, like the Nucleo H743ZI, the command line would look like this:
+
+... and an STM32 board, like the Nucleo H743ZI:
 
 ```
+DEFMT_LOG=debug \
 PROBE_RUN_PROBE='0483:374b' \
 PROBE_RUN_CHIP='STM32H743ZITx' \
-DEFMT_LOG=debug \
 cargo run --no-default-features --target thumbv7em-none-eabihf --features "stm32h743zi"
 ```
 

--- a/client/embedded-app/.cargo/config.toml
+++ b/client/embedded-app/.cargo/config.toml
@@ -7,3 +7,4 @@ rustflags = [
 runner = "probe-run --measure-stack"
 
 [build]
+target = "thumbv7em-none-eabihf"

--- a/client/embedded-app/Cargo.toml
+++ b/client/embedded-app/Cargo.toml
@@ -10,9 +10,9 @@ cortex-m = "0.7"
 cortex-m-rt = "0.7.1"
 defmt = "0.3"
 defmt-rtt = "0.3"
-embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt"] }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt", "time-driver-tim2"], optional = true }
+embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt"] }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt", "time-driver-tim2"], optional = true }
 # Uncomment the next two and comment the two above if you're wanting to hack on Embassy
 #embassy = { path = "../../../../hacking/embassy/embassy", features = ["defmt"] }
 #embassy-nrf = { path = "../../../../hacking/embassy/embassy-nrf", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }

--- a/embassy-start.code-workspace
+++ b/embassy-start.code-workspace
@@ -13,6 +13,8 @@
 	"settings": {
 		"files.watcherExclude": {
 			"**/target": true
-		}
+		},
+    // Needed until https://github.com/rust-analyzer/rust-analyzer/issues/11268 is resolved
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabihf"
 	},
 }

--- a/server/embedded-app/.cargo/config.toml
+++ b/server/embedded-app/.cargo/config.toml
@@ -7,3 +7,4 @@ rustflags = [
 runner = "probe-run --measure-stack"
 
 [build]
+target = "thumbv7em-none-eabihf"

--- a/server/embedded-app/Cargo.toml
+++ b/server/embedded-app/Cargo.toml
@@ -10,9 +10,9 @@ cortex-m = "0.7"
 cortex-m-rt = "0.7.1"
 defmt = "0.3"
 defmt-rtt = "0.3"
-embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt"] }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "ad2f4694070104f8815563a0008141eec29c06cd", features = ["defmt", "time-driver-tim2"], optional = true }
+embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt"] }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "e7668a86bd118ae8c4eb3e695130d7cac90c1dfe", features = ["defmt", "time-driver-tim2"], optional = true }
 # Uncomment the next two and comment the two above if you're wanting to hack on Embassy
 #embassy = { path = "../../../../hacking/embassy/embassy", features = ["defmt"] }
 #embassy-nrf = { path = "../../../../hacking/embassy/embassy-nrf", features = ["defmt", "time-driver-rtc1", "gpiote"], optional = true }


### PR DESCRIPTION
This causes `cargo clippy` issues, along with VS code being unable to resolve some cortex_m related imports.